### PR TITLE
feat(loadModule): support binaryEndpoint for browser

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,4 @@ typings/
 src/
 test/
 !dist/src
+examples/

--- a/examples/node_buffer/index.ts
+++ b/examples/node_buffer/index.ts
@@ -3,7 +3,10 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as Rx from 'rxjs';
 import { loadModule } from '../../src';
+import { enableLogger } from '../../src/logger';
 import { runHunspell } from '../runHunspell';
+
+enableLogger(console.log.bind(console));
 
 const readFile = Rx.Observable.bindNodeCallback(fs.readFile);
 const dictPath = path.resolve('../../spec/__fixtures__');

--- a/examples/node_fs/index.ts
+++ b/examples/node_fs/index.ts
@@ -2,7 +2,10 @@
 import * as path from 'path';
 import * as unixify from 'unixify';
 import { loadModule } from '../../src';
+import { enableLogger } from '../../src/logger';
 import { runHunspell } from '../runHunspell';
+
+enableLogger(console.log.bind(console));
 
 const dictPath = path.resolve('../../spec/__fixtures__');
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "test:cover": "npm-run-all \"test:spec -- --coverage --no-cache --runInBand\"",
     "lint": "tslint src/**/*.ts test/**/*.ts --type-check --project tsconfig.json",
     "lint:staged": "lint-staged",
-    "build": "shx rm -rf ./dist && tsc && shx cp -r ./src/lib ./dist/cjs/src",
+    "build": "shx rm -rf ./dist && tsc && shx cp -r ./src/lib ./dist/src",
     "commit": "git-cz -S",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,18 @@
 import { HunspellFactory } from './Hunspell';
 import { hunspellLoader } from './hunspellLoader';
 import { log } from './logger';
+import { isNode } from './util/isNode';
 import { isWasmEnabled } from './util/isWasmEnabled';
 
-export const loadModule = async (): Promise<HunspellFactory> => {
+/**
+ * Asynchronously load and initialize asm module.
+ *
+ * @param {string} [binaryEndpoint] Provides endpoint to server to download binary module
+ * (.wasm, .mem) via fetch when initialize module in a browser environment.
+ *
+ * @returns {HunspellFactory} Factory function manages lifecycle of hunspell and virtual files.
+ */
+export const loadModule = async (binaryEndpoint?: string): Promise<HunspellFactory> => {
   const asmType = isWasmEnabled() ? 'wasm' : 'asm';
   log(`loadModule: load hunspell module loader from `, asmType);
 
@@ -11,7 +20,16 @@ export const loadModule = async (): Promise<HunspellFactory> => {
   const moduleLoader = require(`./lib/${asmType}/hunspell`);
   log(`loadModule: moduleLoader imported`);
 
-  const asmModule = moduleLoader();
+  const asmModule = !!binaryEndpoint
+    ? moduleLoader({
+        locateFile: (fileName: string) =>
+          isNode()
+            ? //tslint:disable-next-line:no-require-imports
+              require('path').join(binaryEndpoint, fileName)
+            : `${binaryEndpoint}/${fileName}`
+      })
+    : moduleLoader();
+
   await asmModule.initializeRuntime();
   log(`loadModule: initialized hunspell Runtime`);
 

--- a/src/util/isNode.ts
+++ b/src/util/isNode.ts
@@ -1,0 +1,11 @@
+//naïve detection for running environment
+export const isNode = () => {
+  if (typeof process === 'object') {
+    if (typeof process.versions === 'object') {
+      if (typeof process.versions.node !== 'undefined') {
+        return true;
+      }
+    }
+  }
+  return false;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "es5",
-    "outDir": "dist/cjs",
+    "outDir": "dist",
     "lib": [
       "es2016",
       "dom"


### PR DESCRIPTION
This PR exposes `binaryEndpoint` in `loadModule()`, allow to specify endpoint to download wasm / mem binary in browser environment. 