### PR TITLE
test(root): do not include coverage

### DIFF
--- a/jest-hunspell-asm.json
+++ b/jest-hunspell-asm.json
@@ -32,6 +32,7 @@
     "<rootDir>/node_modules/",
     "<rootDir>/spec/.*\\.(ts|js)$",
     "<rootDir>/build/.*\\.(ts|js)$",
-    "<rootDir>/src/lib/.*\\.js$"
+    "<rootDir>/src/lib/.*\\.js$",
+    "<rootDir>/src/util/root.ts"
   ]
 }

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,8 +1,6 @@
 module.exports = (wallaby) => ({
   files: [
-    "src/**/*.ts",
-    { "pattern": "spec/util.ts", "instrument": false, "load": true }
-
+    "src/**/*.ts"
   ],
 
   tests: [


### PR DESCRIPTION
`root` is external code, do not include it in code coverage.